### PR TITLE
Encryption-at-Rest via LUKS: Extend OpenNebula Python LINSTOR Driver for VM Templates, Images/Volumes, and Snapshots

### DIFF
--- a/datastore/clone
+++ b/datastore/clone
@@ -20,10 +20,28 @@ limitations under the License.
 from __future__ import print_function
 
 import sys
+import xml.etree.ElementTree as ET
 
 from one.extender import clone
 from linstor import Resource
 from one import consts, driver_action, util
+
+
+def get_encryption_params(driver):
+    encryption_enabled = False
+    encryption_passphrase = "DEFAULT_PASSPHRASE"
+
+    try:
+        image_root = ET.fromstring(driver.image.xmlstr)
+        template_elem = image_root.find("TEMPLATE")
+
+        if template_elem is not None:
+            encryption_enabled = template_elem.findtext("ENCRYPTION_ENABLED", encryption_enabled)
+            encryption_passphrase = template_elem.findtext("PASSPRHASE", encryption_passphrase)
+
+        return encryption_enabled, encryption_passphrase
+    except Exception:
+        return encryption_enabled, encryption_passphrase
 
 
 def main():
@@ -39,13 +57,17 @@ def main():
 
     clone_name = "{}-{}".format(consts.IMAGE_PREFIX, arg_image_id)
 
+    encryption_enabled, encryption_passphrase = get_encryption_params(driver)
+
     util.log_info("Cloning into new resource '{r}' into resource group '{p}'".format(
         r=clone_name, p=driver.datastore.linstor_resource_group)
     )
     success, _ = clone(
         res,
         clone_name,
-        driver.datastore.linstor_resource_group
+        driver.datastore.linstor_resource_group,
+        encryption_enabled=encryption_enabled,
+        encryption_passphrase=encryption_passphrase
     )
 
     util.log_info("Exiting datastore clone with " + "success." if success else "error.")

--- a/datastore/cp
+++ b/datastore/cp
@@ -20,9 +20,27 @@ limitations under the License.
 from __future__ import print_function
 
 import sys
+import xml.etree.ElementTree as ET
 
 from one.extender import get_device_path, deploy
 from one import consts, driver_action, util
+
+
+def get_encryption_params(driver):
+    encryption_enabled = False
+    encryption_passphrase = "DEFAULT_PASSPHRASE"
+
+    try:
+        image_root = ET.fromstring(driver.image.xmlstr)
+        template_elem = image_root.find("TEMPLATE")
+
+        if template_elem is not None:
+            encryption_enabled = template_elem.findtext("ENCRYPTION_ENABLED", encryption_enabled)
+            encryption_passphrase = template_elem.findtext("PASSPRHASE", encryption_passphrase)
+
+        return encryption_enabled, encryption_passphrase
+    except Exception:
+        return encryption_enabled, encryption_passphrase
 
 
 def main():
@@ -32,11 +50,15 @@ def main():
     driver = driver_action.DriverAction(arg_driver_action)
     resource_name = "{}-{}".format(consts.IMAGE_PREFIX, arg_image_id)
 
+    encryption_enabled, encryption_passphrase = get_encryption_params(driver)
+
     res = deploy(
         linstor_controllers=driver.datastore.linstor_controllers,
         resource_name=resource_name,
         vlm_size_str=driver.image.size + "MiB",
-        resource_group=driver.datastore.linstor_resource_group
+        resource_group=driver.datastore.linstor_resource_group,
+        encryption_enabled = encryption_enabled,
+        encryption_passphrase = encryption_passphrase
     )
 
     util.set_up_datastore(

--- a/datastore/mkfs
+++ b/datastore/mkfs
@@ -20,11 +20,29 @@ from __future__ import print_function
 
 import random
 import sys
+import xml.etree.ElementTree as ET
 
 from linstor import SizeCalc
 from one.extender import deploy
 from one import consts, driver_action, util
 from one.extender import get_device_path
+
+
+def get_encryption_params(driver):
+    encryption_enabled = False
+    encryption_passphrase = "DEFAULT_PASSPHRASE"
+
+    try:
+        image_root = ET.fromstring(driver.image.xmlstr)
+        template_elem = image_root.find("TEMPLATE")
+
+        if template_elem is not None:
+            encryption_enabled = template_elem.findtext("ENCRYPTION_ENABLED", encryption_enabled)
+            encryption_passphrase = template_elem.findtext("PASSPRHASE", encryption_passphrase)
+
+        return encryption_enabled, encryption_passphrase
+    except Exception:
+        return encryption_enabled, encryption_passphrase
 
 
 def main():
@@ -34,6 +52,8 @@ def main():
     driver = driver_action.DriverAction(arg_driver_action)
 
     resource_name = "{}-{}".format(consts.IMAGE_PREFIX, arg_image_id)
+
+    encryption_enabled, encryption_passphrase = get_encryption_params(driver)
 
     is_version6 = util.one_version_larger(5, 12)
 
@@ -59,7 +79,9 @@ def main():
         linstor_controllers=driver.datastore.linstor_controllers,
         resource_name=resource_name,
         vlm_size_str=driver.image.size + "MiB",
-        resource_group=driver.datastore.linstor_resource_group
+        resource_group=driver.datastore.linstor_resource_group,
+        encryption_enabled = encryption_enabled,
+        encryption_passphrase = encryption_passphrase
     )
 
     device_path = get_device_path(res)

--- a/one/extender.py
+++ b/one/extender.py
@@ -70,7 +70,9 @@ def deploy(
         resource_name,
         vlm_size_str,
         resource_group=None,
-        prefer_node=None
+        prefer_node=None,
+        encryption_enabled=False,
+        encryption_passphrase="DEFAULT_PASSPHRASE"
 ):
     """
     Deploys resource depending on resource_group, deployment nodes or auto_place setting.
@@ -82,21 +84,61 @@ def deploy(
     :param Optional[str] prefer_node: Tries to place a diskful on this node(if autoplace)
     :return: Resource object of the new deployment
     :rtype: Resource
+    If encryption_enabled is True, create the resource definition with luks in the layer-list
+    and pass the passphrase for the volume creation.
     """
-    util.log_info("Deploying resource '{}' using resource group '{}', prefer node: {n}".format(
-        resource_name, resource_group, n=prefer_node))
-    resource = Resource.from_resource_group(
-        linstor_controllers,
-        resource_group,
-        resource_name,
-        [vlm_size_str],
-        definitions_only=bool(prefer_node)
-    )
-    if prefer_node:
-        resource.placement.redundancy = None  # force resource group values, default would be 2
-        try_diskful_activate(resource, prefer_node)
-        resource.autoplace()
-    return resource
+    util.log_info("Deploying resource '{}' using resource group '{}', prefer node: {}; encryption: {}".format(
+        resource_name, resource_group, prefer_node, encryption_enabled))
+
+    if not encryption_enabled:
+        resource = Resource.from_resource_group(
+            linstor_controllers,
+            resource_group,
+            resource_name,
+            [vlm_size_str],
+            definitions_only=bool(prefer_node)
+        )
+        if prefer_node:
+            resource.placement.redundancy = None
+            try_diskful_activate(resource, prefer_node)
+            resource.autoplace()
+        return resource
+
+    uri_list = MultiLinstor.controller_uri_list(linstor_controllers)
+    with MultiLinstor(uri_list) as lin:
+        rs = lin.resource_dfn_create(
+            name=resource_name,
+            external_name=resource_name,
+            layer_list=["drbd", "luks", "storage"],
+            resource_group=resource_group
+        )
+        if not lin.all_api_responses_no_error(rs):
+            raise LinstorError("Failed to create encrypted resource-definition {}: {}".format(
+                resource_name, lin.filter_api_call_response_errors(rs)))
+
+        size_kib = lin.parse_volume_size_to_kib(vlm_size_str)
+
+        storage_pool = None
+        if resource_group:
+            rsc_grp = lin.resource_group_list_raise(filter_by_resource_groups=[resource_group])
+            if rsc_grp.resource_groups and rsc_grp.resource_groups[0].select_filter.storage_pool_list:
+                storage_pool = rsc_grp.resource_groups[0].select_filter.storage_pool_list[0]  # Use first
+
+        passphrase = encryption_passphrase
+        vrs = lin.volume_dfn_create(
+            rsc_name=resource_name,
+            size=size_kib,
+            volume_nr=0,
+            storage_pool=storage_pool,
+            passphrase=passphrase
+        )
+        if not lin.all_api_responses_no_error(vrs):
+            raise LinstorError("Failed to create encrypted volume-definition {}: {}".format(
+                resource_name, lin.filter_api_call_response_errors(vrs)))
+
+    res = Resource(resource_name, uri=linstor_controllers)
+    res.autoplace()
+    return res
 
 
 def delete(resource_name, uri_list):
@@ -175,7 +217,9 @@ def clone(
         resource_group=None,
         prefer_node=None,
         new_size=None,
-        allow_dependent_clone=False):
+        allow_dependent_clone=False,
+        encryption_enabled=False,
+        encryption_passphrase="DEFAULT_PASSPHRASE"):
     """
     Clones a resource to a new resource.
 
@@ -192,6 +236,10 @@ def clone(
     util.log_info("Cloning from resource '{src}' to '{tgt}'.".format(src=resource.name, tgt=clone_name))
 
     use_linstor_clone = True
+
+    if encryption_enabled:
+        util.log_info("Encryption requested; forcing COPY mode (no native clone).")
+        use_linstor_clone = False
 
     if resource.resource_group_name and resource.resource_group_name != resource_group:
         # maybe check if resource group is using same storage pools
@@ -210,13 +258,24 @@ def clone(
             try_diskful_activate(clone_res, prefer_node)
     else:
         vol_size_str = str(new_size) + "MiB" if new_size else str(resource.volumes[0].size) + "b"
-        clone_res = deploy(
-            linstor_controllers=linstor_controllers,
-            resource_name=clone_name,
-            vlm_size_str=vol_size_str,
-            resource_group=resource_group,
-            prefer_node=prefer_node
-        )
+        if encryption_enabled:
+            clone_res = deploy(
+                linstor_controllers=linstor_controllers,
+                resource_name=clone_name,
+                vlm_size_str=vol_size_str,
+                resource_group=resource_group,
+                prefer_node=prefer_node,
+                encryption_enabled=True,
+                encryption_passphrase=encryption_passphrase
+            )
+        else:
+            clone_res = deploy(
+                linstor_controllers=linstor_controllers,
+                resource_name=clone_name,
+                vlm_size_str=vol_size_str,
+                resource_group=resource_group,
+                prefer_node=prefer_node
+            )
 
         # use copy source on the current primary node or on one with a disk, if all secondary
         copy_node = get_in_use_node(resource)

--- a/tm/clone
+++ b/tm/clone
@@ -21,6 +21,7 @@ from __future__ import print_function
 
 import os
 import sys
+import xml.etree.ElementTree as ET
 
 from one.extender import clone, get_device_path, resize_disk, resize_if_qcow2, wait_resource_ready
 from linstor import Resource, SizeCalc
@@ -34,6 +35,25 @@ VM_ID = int(sys.argv[3])
 DS_ID = sys.argv[4]
 
 
+def get_encryption_params(vm_id):
+    encryption_enabled = False
+    encryption_passphrase = "DEFAULT_PASSPHRASE"
+    try:
+        vm_xml = util.show_vm(vm_id)
+        root = ET.fromstring(vm_xml)
+        context = root.find(".//CONTEXT")
+
+        if context is not None:
+            encryption_enabled = context.find("ENCRYPTION_ENABLED") is not None
+            passphrase_elem = context.find("ENCRYPTION_PASSPHRASE")
+            if passphrase_elem is not None and passphrase_elem.text:
+                encryption_passphrase = passphrase_elem.text
+
+        return encryption_enabled, encryption_passphrase
+    except Exception:
+        return encryption_enabled, encryption_passphrase
+
+
 def main():
     util.log_info("Entering tm clone src:{s} dst:{d}".format(s=SRC, d=DST))
 
@@ -42,6 +62,8 @@ def main():
     dst_path = util.arg_path(DST).strip()
     dst_dir = os.path.dirname(dst_path).strip()
     disk_id = dst_path.split(".")[-1].strip()
+
+    encryption_enabled, encryption_passphrase = get_encryption_params(VM_ID)
 
     datastore = Datastore(util.show_ds(DS_ID))
     vm = Vm(util.show_vm(VM_ID))
@@ -58,7 +80,9 @@ def main():
         datastore.linstor_resource_group,
         prefer_node=dst_host,
         new_size=new_size,
-        allow_dependent_clone=True
+        allow_dependent_clone=True,allow_dependent_clone=True,
+        encryption_enabled=encryption_enabled,
+        encryption_passphrase=encryption_passphrase
     )
     if not success:
         util.log_error("Cloning resource {} failed.".format(res.name))

--- a/tm/clone
+++ b/tm/clone
@@ -80,7 +80,7 @@ def main():
         datastore.linstor_resource_group,
         prefer_node=dst_host,
         new_size=new_size,
-        allow_dependent_clone=True,allow_dependent_clone=True,
+        allow_dependent_clone=True,
         encryption_enabled=encryption_enabled,
         encryption_passphrase=encryption_passphrase
     )


### PR DESCRIPTION
Summary
This PR extends the official OpenNebula Python-based LINSTOR driver to support encryption-at-rest using LUKS. The enhancement enables secure handling of VM disks, datastore volumes, and snapshots by providing per-resource encryption parameters.

Key Features
VM-level encryption: Controlled via VM template context parameters.
Volume-level encryption: Defined in image template parameters.
Snapshot inheritance: Encryption settings are propagated to snapshots for consistent data protection.
Per-resource passphrase control: Allows unique encryption keys per VM or volume.

Parameters Introduced
ENCRYPTION_ENABLED → Boolean flag to enable LUKS encryption.
ENCRYPTION_PASSPHRASE/PASSPHRASE → Passphrase used to initialize encrypted resources.

Implementation Details
The driver configures encrypted volumes using LUKS on top of LINSTOR-provisioned storage resources.
Passphrases are securely passed to the LINSTOR API at creation time.
Encryption metadata is persisted in OpenNebula templates

Brief Documentation Link:
https://docs.google.com/document/d/1EJVe2bSBioGjQ7UF30ZXiEAixzXB7nqd7Sf_aF6uxe8/edit?usp=sharing